### PR TITLE
Disable uwu-ification for commands

### DIFF
--- a/src/main/java/io/github/ran/uwu/client/mixins/ClientPlayerEntityMixin.java
+++ b/src/main/java/io/github/ran/uwu/client/mixins/ClientPlayerEntityMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 public abstract class ClientPlayerEntityMixin {
     @ModifyVariable(method = "sendChatMessage", at = @At("HEAD"), ordinal = 0, argsOnly = true)
     private String onSendChatMessage(String message) {
+        if (message.startsWith("/")) return message; // ignore commands
         return UwuConfig.uwuifyOutgoing ? Uwuifier.uwu(message) : message;
     }
 }


### PR DESCRIPTION
Just a simple fix that disables uwuification for commands, since it can make them not work